### PR TITLE
Removes build word references from TaskRun

### DIFF
--- a/cmd/nop/main.go
+++ b/cmd/nop/main.go
@@ -19,5 +19,5 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Println("Build successful")
+	fmt.Println("Task completed successfully")
 }

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
@@ -89,8 +89,8 @@ const (
 	// Prefixes to add to the name of the init containers.
 	// IMPORTANT: Changing these values without changing fluentd collection configuration
 	// will break log collection for init containers.
-	containerPrefix            = "build-step-"
-	unnamedInitContainerPrefix = "build-step-unnamed-"
+	containerPrefix            = "step-"
+	unnamedInitContainerPrefix = "step-unnamed-"
 	// Name of the credential initialization container.
 	credsInit = "credential-initializer"
 )
@@ -99,9 +99,9 @@ var (
 	// The container used to initialize credentials before the build runs.
 	credsImage = flag.String("creds-image", "override-with-creds:latest",
 		"The container image for preparing our Build's credentials.")
-	// The container that just prints build successful.
+	// The container that just prints Task completed successfully.
 	nopImage = flag.String("nop-image", "override-with-nop:latest",
-		"The container image run at the end of the build to log build success")
+		"The container image run at the end of the build to log task success")
 )
 
 func makeCredentialInitializer(serviceAccountName, namespace string, kubeclient kubernetes.Interface) (*corev1.Container, []corev1.Volume, error) {

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
@@ -171,7 +171,7 @@ func TestMakePod(t *testing.T) {
 				WorkingDir:   workspaceDir,
 			}},
 			Containers: []corev1.Container{{
-				Name:         "build-step-name",
+				Name:         "step-name",
 				Image:        "image",
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
@@ -217,7 +217,7 @@ func TestMakePod(t *testing.T) {
 				WorkingDir:   workspaceDir,
 			}},
 			Containers: []corev1.Container{{
-				Name:         "build-step-name",
+				Name:         "step-name",
 				Image:        "image",
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
@@ -238,7 +238,7 @@ func TestMakePod(t *testing.T) {
 		desc: "very-long-step-name",
 		ts: v1alpha1.TaskSpec{
 			Steps: []corev1.Container{{
-				Name:  "a-very-long-character-step-name-to-trigger-max-len----and-invalid-characters",
+				Name:  "a-very-very-long-character-step-name-to-trigger-max-len----and-invalid-characters",
 				Image: "image",
 			}},
 		},
@@ -257,7 +257,7 @@ func TestMakePod(t *testing.T) {
 				WorkingDir:   workspaceDir,
 			}},
 			Containers: []corev1.Container{{
-				Name:         "build-step-a-very-long-character-step-name-to-trigger-max-len",
+				Name:         "step-a-very-very-long-character-step-name-to-trigger-max-len",
 				Image:        "image",
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
@@ -297,7 +297,7 @@ func TestMakePod(t *testing.T) {
 				WorkingDir:   workspaceDir,
 			}},
 			Containers: []corev1.Container{{
-				Name:         "build-step-ends-with-invalid",
+				Name:         "step-ends-with-invalid",
 				Image:        "image",
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -350,7 +350,7 @@ func updateStatusFromPod(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
 		taskRun.Status.SetCondition(&apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionUnknown,
-			Reason: "Building",
+			Reason: reasonRunning,
 		})
 	case corev1.PodFailed:
 		msg := getFailureMessage(pod)

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -154,7 +154,7 @@ var (
 
 		actualOps = append(actualOps, ops...)
 
-		return tb.PodInitContainer("build-step-credential-initializer-"+suffix, "override-with-creds:latest", actualOps...)
+		return tb.PodInitContainer("step-credential-initializer-"+suffix, "override-with-creds:latest", actualOps...)
 	}
 
 	getPlaceToolsInitContainer = func(ops ...tb.ContainerOp) tb.PodSpecOp {
@@ -170,7 +170,7 @@ var (
 
 		actualOps = append(actualOps, ops...)
 
-		return tb.PodInitContainer("build-step-place-tools", "override-with-entrypoint:latest", actualOps...)
+		return tb.PodInitContainer("step-place-tools", "override-with-entrypoint:latest", actualOps...)
 	}
 )
 
@@ -369,7 +369,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
-				tb.PodContainer("build-step-simple-step", "foo",
+				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -405,7 +405,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
-				tb.PodContainer("build-step-sa-step", "foo",
+				tb.PodContainer("step-sa-step", "foo",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -446,7 +446,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("mz4c7"),
 				getPlaceToolsInitContainer(),
-				tb.PodContainer("build-step-git-source-git-resource-9l9zj", "override-with-git:latest",
+				tb.PodContainer("step-git-source-git-resource-9l9zj", "override-with-git:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app/git-init", "--",
 						"-url", "https://foo.git", "-revision", "master", "-path", "/workspace/workspace"),
@@ -461,7 +461,7 @@ func TestReconcile(t *testing.T) {
 						tb.EphemeralStorage("0"),
 					)),
 				),
-				tb.PodContainer("build-step-mycontainer", "myimage",
+				tb.PodContainer("step-mycontainer", "myimage",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/mycmd", "--",
 						"--my-arg=foo", "--my-arg-with-default=bar", "--my-arg-with-default2=thedefault",
@@ -477,7 +477,7 @@ func TestReconcile(t *testing.T) {
 						tb.EphemeralStorage("0"),
 					)),
 				),
-				tb.PodContainer("build-step-myothercontainer", "myotherimage",
+				tb.PodContainer("step-myothercontainer", "myotherimage",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/1", "-post_file", "/builder/tools/2", "-entrypoint", "/mycmd", "--",
 						"--my-other-arg=https://foo.git"),
@@ -521,7 +521,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("vr6ds"),
 				getPlaceToolsInitContainer(),
-				tb.PodContainer("build-step-create-dir-another-git-resource-78c5n", "override-with-bash-noop:latest",
+				tb.PodContainer("step-create-dir-another-git-resource-78c5n", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "mkdir -p /workspace/another-git-resource"),
@@ -536,7 +536,7 @@ func TestReconcile(t *testing.T) {
 						tb.EphemeralStorage("0"),
 					)),
 				),
-				tb.PodContainer("build-step-source-copy-another-git-resource-mssqb", "override-with-bash-noop:latest",
+				tb.PodContainer("step-source-copy-another-git-resource-mssqb", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "cp -r source-folder/. /workspace/another-git-resource"),
@@ -552,7 +552,7 @@ func TestReconcile(t *testing.T) {
 						tb.EphemeralStorage("0"),
 					)),
 				),
-				tb.PodContainer("build-step-create-dir-git-resource-mz4c7", "override-with-bash-noop:latest",
+				tb.PodContainer("step-create-dir-git-resource-mz4c7", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/1", "-post_file", "/builder/tools/2", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "mkdir -p /workspace/git-resource"),
@@ -567,7 +567,7 @@ func TestReconcile(t *testing.T) {
 						tb.EphemeralStorage("0"),
 					)),
 				),
-				tb.PodContainer("build-step-source-copy-git-resource-9l9zj", "override-with-bash-noop:latest",
+				tb.PodContainer("step-source-copy-git-resource-9l9zj", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/2", "-post_file", "/builder/tools/3", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "cp -r source-folder/. /workspace/git-resource"),
@@ -583,7 +583,7 @@ func TestReconcile(t *testing.T) {
 						tb.EphemeralStorage("0"),
 					)),
 				),
-				tb.PodContainer("build-step-simple-step", "foo",
+				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/3", "-post_file", "/builder/tools/4", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -597,7 +597,7 @@ func TestReconcile(t *testing.T) {
 						tb.EphemeralStorage("0"),
 					)),
 				),
-				tb.PodContainer("build-step-source-mkdir-git-resource-6nl7g", "override-with-bash-noop:latest",
+				tb.PodContainer("step-source-mkdir-git-resource-6nl7g", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/4", "-post_file", "/builder/tools/5", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "mkdir -p output-folder"),
@@ -613,7 +613,7 @@ func TestReconcile(t *testing.T) {
 						tb.EphemeralStorage("0"),
 					)),
 				),
-				tb.PodContainer("build-step-source-copy-git-resource-j2tds", "override-with-bash-noop:latest",
+				tb.PodContainer("step-source-copy-git-resource-j2tds", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/5", "-post_file", "/builder/tools/6", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "cp -r /workspace/git-resource/. output-folder"),
@@ -649,7 +649,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("mz4c7"),
 				getPlaceToolsInitContainer(),
-				tb.PodContainer("build-step-git-source-git-resource-9l9zj", "override-with-git:latest",
+				tb.PodContainer("step-git-source-git-resource-9l9zj", "override-with-git:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app/git-init", "--",
 						"-url", "https://foo.git", "-revision", "master", "-path", "/workspace/workspace"),
@@ -664,7 +664,7 @@ func TestReconcile(t *testing.T) {
 						tb.EphemeralStorage("0"),
 					)),
 				),
-				tb.PodContainer("build-step-mycontainer", "myimage",
+				tb.PodContainer("step-mycontainer", "myimage",
 					tb.Command(entrypointLocation),
 					tb.WorkingDir(workspaceDir),
 					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/mycmd", "--",
@@ -700,7 +700,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
-				tb.PodContainer("build-step-simple-step", "foo",
+				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -734,7 +734,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("mz4c7"),
 				getPlaceToolsInitContainer(),
-				tb.PodContainer("build-step-git-source-workspace-9l9zj", "override-with-git:latest",
+				tb.PodContainer("step-git-source-workspace-9l9zj", "override-with-git:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app/git-init", "--",
 						"-url", "github.com/foo/bar.git", "-revision", "rel-can", "-path",
@@ -750,7 +750,7 @@ func TestReconcile(t *testing.T) {
 						tb.EphemeralStorage("0"),
 					)),
 				),
-				tb.PodContainer("build-step-mystep", "ubuntu",
+				tb.PodContainer("step-mystep", "ubuntu",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -786,7 +786,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
-				tb.PodContainer("build-step-simple-step", "foo",
+				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -821,7 +821,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("9l9zj", tb.EnvVar("FRUIT", "APPLE")),
 				getPlaceToolsInitContainer(tb.EnvVar("FRUIT", "APPLE")),
-				tb.PodContainer("build-step-env-step", "foo", tb.Command(entrypointLocation),
+				tb.PodContainer("step-env-step", "foo", tb.Command(entrypointLocation),
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -858,7 +858,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
-				tb.PodContainer("build-step-step1", "foo",
+				tb.PodContainer("step-step1", "foo",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -878,7 +878,7 @@ func TestReconcile(t *testing.T) {
 						),
 					),
 				),
-				tb.PodContainer("build-step-step2", "foo",
+				tb.PodContainer("step-step2", "foo",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -895,7 +895,7 @@ func TestReconcile(t *testing.T) {
 						),
 					),
 				),
-				tb.PodContainer("build-step-step3", "foo",
+				tb.PodContainer("step-step3", "foo",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/tools/1", "-post_file", "/builder/tools/2", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -930,7 +930,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
-				tb.PodContainer("build-step-simple-step", "foo",
+				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/mycmd", "--"),
 					tb.WorkingDir(workspaceDir),
@@ -1375,7 +1375,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 	conditionBuilding := apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionUnknown,
-		Reason: "Building",
+		Reason: reasonRunning,
 	}
 	for _, c := range []struct {
 		desc      string
@@ -1452,7 +1452,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 		podStatus: corev1.PodStatus{
 			Phase: corev1.PodSucceeded,
 			ContainerStatuses: []corev1.ContainerStatus{{
-				Name: "build-step-build-step-push",
+				Name: "step-step-push",
 				State: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 0,
@@ -1469,7 +1469,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 0,
 					}},
-				Name: "build-step-push",
+				Name: "step-push",
 			}},
 			// We don't actually care about the time, just that it's not nil
 			CompletionTime: &metav1.Time{Time: time.Now()},
@@ -1479,7 +1479,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 		podStatus: corev1.PodStatus{
 			Phase: corev1.PodRunning,
 			ContainerStatuses: []corev1.ContainerStatus{{
-				Name: "build-step-running-step",
+				Name: "step-running-step",
 				State: corev1.ContainerState{
 					Running: &corev1.ContainerStateRunning{},
 				},
@@ -1504,7 +1504,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 				// creds-init status; ignored
 			}},
 			ContainerStatuses: []corev1.ContainerStatus{{
-				Name:    "build-step-failure",
+				Name:    "step-failure",
 				ImageID: "image-id",
 				State: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
@@ -1518,7 +1518,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 				Conditions: []apis.Condition{{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
-					Message: `"build-step-failure" exited with code 123 (image: "image-id"); for logs run: kubectl -n foo logs pod -c build-step-failure`,
+					Message: `"step-failure" exited with code 123 (image: "image-id"); for logs run: kubectl -n foo logs pod -c step-failure`,
 				}},
 			},
 			Steps: []v1alpha1.StepState{{

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -115,7 +115,7 @@ func TestGitPipelineRunFail(t *testing.T) {
 				}
 
 				for _, stat := range p.Status.ContainerStatuses {
-					if strings.HasPrefix(stat.Name, "build-step-git-source-"+gitSourceResourceName) {
+					if strings.HasPrefix(stat.Name, "step-git-source-"+gitSourceResourceName) {
 						if stat.State.Terminated != nil {
 							req := c.KubeClient.Kube.CoreV1().Pods(namespace).GetLogs(p.Name, &corev1.PodLogOptions{Container: stat.Name})
 							logContent, err := req.Do().Raw()

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -40,7 +40,7 @@ const (
 	kanikoTaskName     = "kanikotask"
 	kanikoTaskRunName  = "kanikotask-run"
 	kanikoResourceName = "go-example-git"
-	kanikoBuildOutput  = "Build successful"
+	kanikoBuildOutput  = "Task completed successfully"
 )
 
 func getGitResource(namespace string) *v1alpha1.PipelineResource {

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -74,6 +74,14 @@ func TestTaskRunFailure(t *testing.T) {
 	expectedStepState := []v1alpha1.StepState{{
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Reason:   "Completed",
+			},
+		},
+		Name: "nop",
+	}, {
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
 				ExitCode: 1,
 				Reason:   "Error",
 			},
@@ -95,14 +103,6 @@ func TestTaskRunFailure(t *testing.T) {
 			},
 		},
 		Name: "world",
-	}, {
-		ContainerState: corev1.ContainerState{
-			Terminated: &corev1.ContainerStateTerminated{
-				ExitCode: 0,
-				Reason:   "Completed",
-			},
-		},
-		Name: "nop",
 	}}
 	ignoreFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
 	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreFields); d != "" {


### PR DESCRIPTION
# Changes

At present `TaskRun's` `status`, it's pod containers name(`step name`
prefix) and logs has references to `build` keyword.
Which kind of gives the perception that `Task` is intended to
perform only build operations.

This patch removes those references from `TaskRun`.

Fixes
 - #815

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

